### PR TITLE
Add additional Pushover parameters

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/notify.pushover/
 import logging
 
 from homeassistant.components.notify import (
-    ATTR_TITLE, DOMAIN, BaseNotificationService)
+    ATTR_TITLE, ATTR_TARGET, ATTR_DATA, DOMAIN, BaseNotificationService)
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import validate_config
 
@@ -51,7 +51,21 @@ class PushoverNotificationService(BaseNotificationService):
         """Send a message to a user."""
         from pushover import RequestError
 
+        data = kwargs.get(ATTR_DATA)
+
+        if not data:
+            data = {}
+
+        data['title'] = kwargs.get(ATTR_TITLE)
+
+        target = kwargs.get(ATTR_TARGET)
+
+        if target is not None:
+            data['device'] = target
+
         try:
-            self.pushover.send_message(message, title=kwargs.get(ATTR_TITLE))
+            self.pushover.send_message(message, **data)
+        except ValueError as val_err:
+            _LOGGER.error(str(val_err))
         except RequestError:
             _LOGGER.exception("Could not send pushover notification")


### PR DESCRIPTION
**Description:**
Add support for more Pushover parameters: target (device), sound, url, url_title, priority, timestamp

**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#

**Example entry for `configuration.yaml` (if applicable):**
```yaml
automation:
  alias: Garage Door is Open
  trigger:
    platform: state
    entity_id: sensor.garage_door
    state: 'open'
  action:
    service: notify.pushover
    data:
      title: Garage Door
      message: The garage door is open.
      target: iPhone,MacBookPro
      data:
        url: https://home-assistant.io/
        url_title: Home Assistant
        priority: 1
        timestamp: 1466024112
        sound: siren
```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If code communicates with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[fork]: http://stackoverflow.com/a/7244456
[squash]: https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51
